### PR TITLE
Fix showFirstContactAsync example

### DIFF
--- a/versions/v16.0.0/sdk/contacts.md
+++ b/versions/v16.0.0/sdk/contacts.md
@@ -51,7 +51,7 @@ async function showFirstContactAsync() {
   if (contacts.total > 0) {
     Alert.alert(
       'Your first contact is...',
-      `Name: ${contacts[0].name}\n` +
+      `Name: ${contacts.data[0].name}\n` +
       `Phone: ${JSON.stringify(contacts.data[0].phoneNumbers)}\n` +
       `Email: ${JSON.stringify(contacts.data[0].emails)}`
     );


### PR DESCRIPTION
This example references the first contact's name using contacts[0] instead of contacts.data[0]. The
other fields were already using contacts.data[0] as aligned with version 16 of the SDK.