### PR TITLE
Fix WebBrowser API docs

### DIFF
--- a/versions/v17.0.0/sdk/webbrowser.md
+++ b/versions/v17.0.0/sdk/webbrowser.md
@@ -36,7 +36,7 @@ Opens the url with the system's web browser.
 
 #### Returns
 
-If the user closed the web browser, the promise resolves with `{ type: cancelled }`.
+If the user closed the web browser, the promise resolves with `{ type: cancel }`.
 If the browser is closed using `Expo.WebBrowser.dismissBrowser()`, the promise resolves with `{ type: dismissed }`.
 
 ### `Expo.WebBrowser.dismissBrowser()`


### PR DESCRIPTION
Found a minor issue w/ the WebBrowser API docs.

Relevant source code: 

- iOS: https://github.com/expo/expo/blob/e6d79644f3b83f2922ab8f0892eec7f6efc1f3cf/ios/versioned-react-native/ABI17_0_0/Exponent/Modules/Api/ABI17_0_0EXWebBrowser.m#L87
- Android https://github.com/expo/expo/blob/8912182d3b28c331ab310119e49c7b5405107b6e/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/WebBrowserModule.java#L95