### PR TITLE
Fix link location for ExpoKit in CRNA docs

### DIFF
--- a/versions/unversioned/guides/create-react-native-app.md
+++ b/versions/unversioned/guides/create-react-native-app.md
@@ -59,7 +59,7 @@ exp and it will work as expected.
 ### What does using ExpoKit mean for a CRNA user?
 
 If you want to add custom native code to your Expo app, you will need to
-[use ExpoKit](exponentkit.html). With CRNA, you have two options: you
+[use ExpoKit](expokit.html). With CRNA, you have two options: you
 can either eject to a normal React Native project, without any
 dependencies on Expo, or you can eject to use ExpoKit, which will allow
 you to continue using the Expo APIs. [Read more about ejecting with CRNA

--- a/versions/v14.0.0/guides/create-react-native-app.md
+++ b/versions/v14.0.0/guides/create-react-native-app.md
@@ -59,7 +59,7 @@ exp and it will work as expected.
 ### What does using ExpoKit mean for a CRNA user?
 
 If you want to add custom native code to your Expo app, you will need to
-[use ExpoKit](exponentkit.html). With CRNA, you have two options: you
+[use ExpoKit](expokit.html). With CRNA, you have two options: you
 can either eject to a normal React Native project, without any
 dependencies on Expo, or you can eject to use ExpoKit, which will allow
 you to continue using the Expo APIs. [Read more about ejecting with CRNA

--- a/versions/v15.0.0/guides/create-react-native-app.md
+++ b/versions/v15.0.0/guides/create-react-native-app.md
@@ -59,7 +59,7 @@ exp and it will work as expected.
 ### What does using ExpoKit mean for a CRNA user?
 
 If you want to add custom native code to your Expo app, you will need to
-[use ExpoKit](exponentkit.html). With CRNA, you have two options: you
+[use ExpoKit](expokit.html). With CRNA, you have two options: you
 can either eject to a normal React Native project, without any
 dependencies on Expo, or you can eject to use ExpoKit, which will allow
 you to continue using the Expo APIs. [Read more about ejecting with CRNA

--- a/versions/v16.0.0/guides/create-react-native-app.md
+++ b/versions/v16.0.0/guides/create-react-native-app.md
@@ -59,7 +59,7 @@ exp and it will work as expected.
 ### What does using ExpoKit mean for a CRNA user?
 
 If you want to add custom native code to your Expo app, you will need to
-[use ExpoKit](exponentkit.html). With CRNA, you have two options: you
+[use ExpoKit](expokit.html). With CRNA, you have two options: you
 can either eject to a normal React Native project, without any
 dependencies on Expo, or you can eject to use ExpoKit, which will allow
 you to continue using the Expo APIs. [Read more about ejecting with CRNA

--- a/versions/v17.0.0/guides/create-react-native-app.md
+++ b/versions/v17.0.0/guides/create-react-native-app.md
@@ -59,7 +59,7 @@ exp and it will work as expected.
 ### What does using ExpoKit mean for a CRNA user?
 
 If you want to add custom native code to your Expo app, you will need to
-[use ExpoKit](exponentkit.html). With CRNA, you have two options: you
+[use ExpoKit](expokit.html). With CRNA, you have two options: you
 can either eject to a normal React Native project, without any
 dependencies on Expo, or you can eject to use ExpoKit, which will allow
 you to continue using the Expo APIs. [Read more about ejecting with CRNA


### PR DESCRIPTION
Right now they link to `https://docs.expo.io/versions/v17.0.0/guides/exponentkit.html`, which isn't a valid url.  I'm assuming you meant to link to `expokit.html`.  This fixes that.