### PR TITLE
Fix small typo

### DIFF
--- a/versions/v17.0.0/sdk/video.md
+++ b/versions/v17.0.0/sdk/video.md
@@ -39,7 +39,7 @@ The `useNativeControls`, `resizeMode`, and `usePoster` props customize the UI of
 
 - `useNativeControls`
 
-  A boolean which, if set to `true`, will display native playback controls (such as play and pause) within the `Video` componet.
+  A boolean which, if set to `true`, will display native playback controls (such as play and pause) within the `Video` component.
 
 - `resizeMode`
 


### PR DESCRIPTION
`componet` to `component`