### PR TITLE
Include advanced tip for windows users

### DIFF
--- a/versions/unversioned/guides/genymotion.md
+++ b/versions/unversioned/guides/genymotion.md
@@ -31,3 +31,39 @@ Choose one of these two options:
 Run `npm install -g exp` to install `exp` globally.
 
 Then run `exp path`. This will save your `PATH` environment variable so that XDE knows where to find your Android tools.
+
+* * *
+### Windows users
+
+If you have been developing React Native apps on Windows for a while, you may have used a few different simulators before  Genymotion. Because of this, you may have initially setup your path to use Android Studio but currently use Genymotion and it's own SDK to simulate apps. If you want to use Expo, but don't want to mess around with changing the path from using Android SDK to genymotion SDK, try doing the following (This also applies to people who are switching from using react native cli w/ genymotion to using Expo):
+
+1. Locate your SDK folder. If you are unsure where it is:
+    1. Open Android Studio
+    2. Configure --> SDK Manager
+    
+    
+    ![Configure SDK](http://i.imgur.com/lydxjzl.png)
+    
+    3. In SDK Manager, make sure you are in Appearance & Behaviour --> System Settings --> Android SDK.
+       Your SDK and tools are in the box that says Android SDK Location. Remember this! You will need to give the location to genymotion
+       
+       
+       ![Android SDK location](http://i.imgur.com/ar2ezyu.png)
+       
+    4. With that address, open up Genymotion --> Settings --> Choose 'Use Custom Android SDK tools' --> Enter in the location you got from Android Studio:
+    
+    ![Change Genymotion Settings](http://i.imgur.com/G4B9f0P.png)
+    
+    
+    5. Open up command prompt and type in exp path
+    
+    6. Start Genymotion
+    
+    7. You will see the following screen pop up. Enable Expo to permit drawing over other apps, and then press the back button on the simulator
+    
+    
+    ![Expo genymotion](http://i.imgur.com/gxNtvhb.png)
+    
+    8. You are now able to Expo with Genymotion on windows!
+
+


### PR DESCRIPTION
If a windows user has been developing with React Native for a while (specifically using the react-native cli to build projects on a genymotion simulator) they may become confused when switching from using the react native cli to simulate apps on genymotion to using exp to simulating apps on genymotion. I ran into this problem, and wrote this guide to help anyone else who may have questions. Hopefully this will help others!