### PR TITLE
Update ExpoSecureStore.js documentation

### DIFF
--- a/versions/v20.0.0/sdk/securestore.md
+++ b/versions/v20.0.0/sdk/securestore.md
@@ -57,7 +57,7 @@ Fetch the stored value associated with the provided key.
 
 A `Promise` containing the fetched value.  The `Promise` will reject if the value cannot be fetched or doesn't exist.
 
-### `Expo.FileSystem.deleteValueWithKeyAsync(key, options)`
+### `Expo.SecureStore.deleteValueWithKeyAsync(key, options)`
 
 Delete the value associated with the provided key.
 

--- a/versions/v20.0.0/sdk/securestore.md
+++ b/versions/v20.0.0/sdk/securestore.md
@@ -67,7 +67,7 @@ Delete the value associated with the provided key.
 
 -   **options (_object_)** (optional) -- A map of options:
   
-  -   **keychainService (_string_)** -- iOS: The item's service, equivalent to `kSecAttrService`.  Android: Equivalent of the public/private key pair `Alias`.  If the item is set with a keychainService, it will be required to later fetch the value.
+    -   **keychainService (_string_)** -- iOS: The item's service, equivalent to `kSecAttrService`.  Android: Equivalent of the public/private key pair `Alias`.  If the item is set with a keychainService, it will be required to later fetch the value.
 
 #### Returns
 


### PR DESCRIPTION
`deleteValueWithKeyAsync` function is a part of `SecureStore`, not `FileSystem`.