### PR TITLE
iOS may throw Error if Audio URI doesn't end with File Type

### DIFF
--- a/versions/v20.0.0/sdk/audio.md
+++ b/versions/v20.0.0/sdk/audio.md
@@ -96,7 +96,7 @@ A static convenience method to construct and load a sound is also provided:
 
     -   **source (_object_ / _number_ / _Asset_)** -- The source of the sound. The following forms are supported:
 
-        -   A dictionary of the form `{ uri: 'http://path/to/file' }` with a network URL pointing to an audio file on the web.
+        -   A dictionary of the form `{ uri: 'http://path/to/file' }` with a network URL pointing to an audio file on the web.(Note: iOS may throw an 'AVPlayerItem instance has failed...' error if the url does not end in the filetype, e.g. http://path/to/file.mp3).
         -   `require('path/to/file')` for an audio file asset in the source code directory.
         -   An [`Expo.Asset`](asset.html) object for an audio file asset.
 


### PR DESCRIPTION
Found this problem while testing an app on iOS but couldn't find any documentation pointing to why I received the error.

 I stored an audio file on S3 with a URL like https://s3.eu-west-2.amazonaws.com/my-bucket/my-file. The file plays correctly on Android but on iOS the file gives the error:

"The AVPlayerItem instance has failed with the error code -11828 and domain "AVFoundationErrorDomain"

I tried changing the Content-Type header to audio/mpeg but this made no difference. When I change the filename to https://s3.eu-west-2.amazonaws.com/my-bucket/my-file.mp3, the file plays correctly on iOS.

I brought the issue up on slack here: https://expo-developers.slack.com/archives/C04Q3JTSV/p1503415117000526 where it was suggested I propose the change as I had difficulty finding what the error meant and resorted to trial-and-error. It might be beneficial to clarify this in the docs for future users if this is the intended behaviour.