### PR TITLE
Noting iOS tabletsSupport default is false

### DIFF
--- a/versions/v20.0.0/guides/configuration.md
+++ b/versions/v20.0.0/guides/configuration.md
@@ -239,7 +239,7 @@ The following is a list of properties that are available for you under the `"exp
 
    - `supportsTablet`
 
-      Whether your standalone iOS app supports tablet screen sizes.
+      Whether your standalone iOS app supports tablet screen sizes. If not provided, defaults to `false`
 
    - `isTabletOnly`
 


### PR DESCRIPTION
Since this isn't clear in the docs and isn't represented when simulating in the XDE (acts like the app is supported in tablets).