### PR TITLE
Fix text "splash for standalone Android apps"

### DIFF
--- a/versions/v21.0.0/guides/configuration.md
+++ b/versions/v21.0.0/guides/configuration.md
@@ -349,7 +349,7 @@ The following is a list of properties that are available for you under the `"exp
 
    - `splash`
 
-      *Experimental*: Configuration for loading and splash screen for standalone iOS apps.
+      *Experimental*: Configuration for loading and splash screen for standalone Android apps.
 
        - `backgroundColor`
 


### PR DESCRIPTION
In Android > splash section, changed iOS to Android