### PR TITLE
Update ios.buildNumber and android.versionCode

### DIFF
--- a/versions/v21.0.0/guides/configuration.md
+++ b/versions/v21.0.0/guides/configuration.md
@@ -175,7 +175,7 @@ The following is a list of properties that are available for you under the `"exp
 
    - `buildNumber`
 
-      Build number for your iOS standalone app
+      Build number for your iOS standalone app. (Must be a string containing a number)
 
    - `icon`
 
@@ -265,7 +265,7 @@ The following is a list of properties that are available for you under the `"exp
 
    - `versionCode`
 
-      Version number required by Google Play. Increment by one for each release. https://developer.android.com/studio/publish/versioning.html.
+      Version number required by Google Play. Increment by one for each release. https://developer.android.com/studio/publish/versioning.html. (Must be an integer)
 
    - `icon`
 


### PR DESCRIPTION
Got following warnings so updating doc: 

For ios.buildNumber:
Warning: Problem validating fields in app.json. See https://docs.expo.io/versions/v21.0.0/guides/configuration.html.
 • 'ios.buildNumber' should match pattern "^[0-9]+$".

For android.versionCode
Warning: Problem validating fields in app.json. See https://docs.expo.io/versions/v21.0.0/guides/configuration.html.
 • should be integer.