### PR TITLE
Update clojurescript guide to point at more up to date leiningen template

### DIFF
--- a/versions/v22.0.0/guides/using-clojurescript.md
+++ b/versions/v22.0.0/guides/using-clojurescript.md
@@ -10,9 +10,9 @@ next___FILE: ./using-firebase.md
 If you're already convinced about ClojureScript and Expo and know what to do once you have figwheel running, you can just read this section. Otherwise, we encourage you to read the entire guide.
 
 ```javascript
-lein new exponent your-project
+lein new expo your-project
 
-cd your-project && npm install
+cd your-project && yarn install
 
 lein figwheel
 
@@ -44,12 +44,12 @@ It all begins with a [Simple Made Easy](https://www.infoq.com/presentations/Simp
 
 ```javascript
 # Default to use Reagent / Re-frame
-lein new exponent your-project
+lein new expo your-project
 
 # Or Om Next
-lein new exponent your-project +om
+lein new expo your-project +om
 
-cd your-project && npm install
+cd your-project && yarn install
 ```
 
 ## 2. Connect to a REPL


### PR DESCRIPTION
I started a new project recently and ran into some troubles that were caused by using the outdated leiningen template mentioned in the current guide. After asking for help in slack, I was asked to try again with the more up to date template and I got my code to work on the first try. This PR updates the guide to tell new users to use the up to date leiningen template.