### PR TITLE
Make json keys consistent style

### DIFF
--- a/versions/v23.0.0/guides/push-notifications.md
+++ b/versions/v23.0.0/guides/push-notifications.md
@@ -45,7 +45,7 @@ async function registerForPushNotificationsAsync() {
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json',
+      Content-Type: 'application/json',
     },
     body: JSON.stringify({
       token: {


### PR DESCRIPTION
In the push notification example where the client posts the token to the backend, make the json keys consistently styled.