### PR TITLE
Update building-standalone-apps.md

### DIFF
--- a/versions/v23.0.0/guides/building-standalone-apps.md
+++ b/versions/v23.0.0/guides/building-standalone-apps.md
@@ -96,7 +96,7 @@ This will take a few minutes, you can check up on it by running `exp build:statu
 
 -   You can drag and drop the `.apk` into your Android emulator. This is the easiest way to test out that the build was successful. But it's not the most satisfying.
 -   **To run it on your Android device**, make sure you have the Android platform tools installed along with `adb`, then just run `adb install app-filename.apk` with your device plugged in.
--   **To run it on your iOS Simulator**, first build your expo project with the simulator flag by running `exp build:ios -t simulator`, then download the tarball with the link given upon completion when running `exp build:status`. Unpack the tar.gz by running `tar -xvzf your-app.tar.gz`. Then you can run it by starting an iOS Simulator instance, then running `xcrun simctl install booted <app path>` and `xcrun simctl launch booted <app identifier>`. Another alternative which some people prefer is to install the [ios-sim](https://github.com/phonegap/ios-sim) tool and then use `ios-sim launch <app path>`.
+-   **To run it on your iOS Simulator**, first build your expo project with the simulator flag by running `exp build:ios -t simulator`, then download the tarball with the link given upon completion when running `exp build:status`. Unpack the tar.gz by running `tar -xvzf your-app.tar.gz`. Then you can run it by starting an iOS Simulator instance, then running `xcrun simctl install booted </absolute/path/to/app/app-name.app>` and `xcrun simctl launch booted <app identifier>`. Another alternative which some people prefer is to install the [ios-sim](https://github.com/phonegap/ios-sim) tool and then use `ios-sim launch </absolute/path/to/app/app-name.app>`.
 
 ## 5.5 - Uploading your iOS IPA to TestFlight
 


### PR DESCRIPTION
It was not clear for me at first, that
1. The app path should be absolute, and could not be relational to where the terminal call was made
2. That you have to include .app in the path - I tried .ipa first, then different variations of paths to the folder the app was located in, and finally .app

This change should help clarify this