### PR TITLE
Fixing method names in brightness.md

### DIFF
--- a/versions/v25.0.0/sdk/brightness.md
+++ b/versions/v25.0.0/sdk/brightness.md
@@ -3,7 +3,7 @@ title: Brightness
 ---
 An API to get and set screen brightness.
 
-### `Expo.Brightness.setBrightness(brightnessValue)`
+### `Expo.Brightness.setBrightnessAsync(brightnessValue)`
 Sets screen brightness.
 
 #### Arguments
@@ -16,7 +16,7 @@ Gets screen brightness.
 #### Returns
 A `Promise` that is resolved with a number between 0 and 1, representing the current screen brightness. 
 
-### `Expo.Brightness.setSystemBrightness(brightnessValue)`
+### `Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`
 > **WARNING:** this method is experimental.
 
 Sets global system screen brightness, requires `WRITE_SETTINGS` permissions on Android.
@@ -32,7 +32,7 @@ await Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
 
 const { status } = await Permissions.getAsync(Permissions.SYSTEM_BRIGHTNESS);
 if (status === 'granted') {
-  Expo.Brightness.setSystemBrightness(100);
+  Expo.Brightness.setSystemBrightnessAsync(1);
 }
 ...
 ```


### PR DESCRIPTION
The method names [all have 'Async' at the end of them](https://github.com/expo/expo-sdk/blob/master/src/Brightness.js), whereas they weren't documented properly. The example also used a value of 100, instead of a value between 0 and 1.