### PR TITLE
On windows, need to manually populate .lan-ip

### DIFF
--- a/versions/v25.0.0/guides/using-clojurescript.md
+++ b/versions/v25.0.0/guides/using-clojurescript.md
@@ -51,8 +51,12 @@ lein new expo your-project +om
 
 cd your-project && yarn install
 ```
-
-## 2. Configure the project
+## 2. Checkpoint: Test your Expo setup
+```javascript
+lein prod-build
+expo start
+```
+## 3. Configure the project for figwheel
 ### Put your IP address in .lan-ip
 Edit or create the file .lan-ip. The file should simply contain your IP address.
 
@@ -61,7 +65,7 @@ Edit the file .expo/settings.json. Set the hostType to "lan"
 ```javascript
 "hostType": "lan"
 ```
-## 3. Connect to a REPL
+## 4. Connect to a REPL
 
 ### CLI REPL
 
@@ -91,7 +95,7 @@ In Intellij make sure your REPL config is selected and click the green **play** 
 
 Run `(start-figwheel)` in the connected REPL.
 
-## 4. Start Expo server
+## 5. Start Expo server
 
 ### Using `exp` CLI
 
@@ -118,7 +122,7 @@ For more information, see [exp Command-Line Interface](exp-cli.html#exp-cli).
 
 For more information, see [XDE tour](../introduction/xde-tour.html#xde-tour).
 
-## 5. Publish your app
+## 6. Publish your app
 
 ```javascript
 # Generate main.js

--- a/versions/v25.0.0/guides/using-clojurescript.md
+++ b/versions/v25.0.0/guides/using-clojurescript.md
@@ -54,7 +54,7 @@ cd your-project && yarn install
 ## 2. Checkpoint: Test your Expo setup
 ```javascript
 lein prod-build
-expo start
+exp start
 ```
 ## 3. Configure the project for figwheel
 ### Put your IP address in .lan-ip

--- a/versions/v25.0.0/guides/using-clojurescript.md
+++ b/versions/v25.0.0/guides/using-clojurescript.md
@@ -106,7 +106,7 @@ exp start --ios
 ```javascript
 exp start
 ```
-Once you connect, in the Expo app on the device, turn off Enable Live Reload and Enable Hot Reloading.
+Once you connect, in the Expo app on the device, disable Live Reload and Hot Reloading.
 
 # Or connect to Android devices or simulators
 exp start --android

--- a/versions/v25.0.0/guides/using-clojurescript.md
+++ b/versions/v25.0.0/guides/using-clojurescript.md
@@ -54,7 +54,7 @@ cd your-project && yarn install
 
 ## 2. Configure the project
 ### Put your IP address in .lan-ip
-Edit or create the file .lan-ip. The file should simple contain your IP address.
+Edit or create the file .lan-ip. The file should simply contain your IP address.
 
 ### Set Expo Host Type to LAN
 Edit the file .expo/settings.json. Set the hostType to "lan"
@@ -101,9 +101,12 @@ npm install -g exp
 
 # Connect to iOS simulator
 exp start --ios
-
+```
 # Connect to iOS device
+```javascript
 exp start
+```
+Once you connect, in the Expo app on the device, turn off Enable Live Reload and Enable Hot Reloading.
 
 # Or connect to Android devices or simulators
 exp start --android

--- a/versions/v25.0.0/guides/using-clojurescript.md
+++ b/versions/v25.0.0/guides/using-clojurescript.md
@@ -52,7 +52,16 @@ lein new expo your-project +om
 cd your-project && yarn install
 ```
 
-## 2. Connect to a REPL
+## 2. Configure the project
+### Put your IP address in .lan-ip
+Edit or create the file .lan-ip. The file should simple contain your IP address.
+
+### Set Expo Host Type to LAN
+Edit the file .expo/settings.json. Set the hostType to "lan"
+```javascript
+"hostType": "lan"
+```
+## 3. Connect to a REPL
 
 ### CLI REPL
 
@@ -82,7 +91,7 @@ In Intellij make sure your REPL config is selected and click the green **play** 
 
 Run `(start-figwheel)` in the connected REPL.
 
-## 3. Start Expo server
+## 4. Start Expo server
 
 ### Using `exp` CLI
 
@@ -92,6 +101,9 @@ npm install -g exp
 
 # Connect to iOS simulator
 exp start --ios
+
+# Connect to iOS device
+exp start
 
 # Or connect to Android devices or simulators
 exp start --android
@@ -103,7 +115,7 @@ For more information, see [exp Command-Line Interface](exp-cli.html#exp-cli).
 
 For more information, see [XDE tour](../introduction/xde-tour.html#xde-tour).
 
-## 4. Publish your app
+## 5. Publish your app
 
 ```javascript
 # Generate main.js


### PR DESCRIPTION
Fixed doc bug that failed to say you need to use LAN, cos figwheel does not support tunnel, and you need to make sure you have .lan-ip populated.