### PR TITLE
Fix ugly font fallback on Windows

### DIFF
--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -42,7 +42,7 @@
     "tippy.js": "^1.2.0",
     "typeface-source-code-pro": "^0.0.35",
     "typeface-source-sans-pro": "^0.0.35",
-    "typography": "^0.16.0",
+    "typography": "^0.16.5",
     "typography-plugin-code": "^0.15.11",
     "unist-util-inspect": "^4.1.1"
   }

--- a/gatsby/src/utils/typography.js
+++ b/gatsby/src/utils/typography.js
@@ -9,6 +9,7 @@ const typography = new Typography({
   headerFontFamily: [
     '-apple-system',
     'system-ui',
+    'Segoe UI',
     'Roboto',
     'Ubuntu',
     'Cantarell',
@@ -20,6 +21,7 @@ const typography = new Typography({
   bodyFontFamily: [
     '-apple-system',
     'system-ui',
+    'Segoe UI',
     'Roboto',
     'Ubuntu',
     'Cantarell',


### PR DESCRIPTION
In Edge and IE11 the font selection is falling back to Times New Roman and is quite hard to read. This is for a couple of reasons:

1. The current version of `typography` used is putting `sans-serif` in quotes which Edge and IE11 then ignore because I think they try to find a font called "sans-serif" 😄 
2. The Windows system font, Segoe UI, isn't in the font list

This PR updates `typography` to 0.16.5 which has a fix for sans-serif. It also places Segoe UI into the header and body font lists.

Times New Roman:
<img width="327" alt="screen shot 2018-02-12 at 21 03 17" src="https://user-images.githubusercontent.com/1379888/36119595-4c84082c-1038-11e8-9b5b-8370562b3107.png">

Segoe UI:
<img width="367" alt="screen shot 2018-02-12 at 21 03 07" src="https://user-images.githubusercontent.com/1379888/36119609-582dd090-1038-11e8-998a-980788b27441.png">
