### PR TITLE
Remove 'notification' mention from System Permission

### DIFF
--- a/versions/unversioned/guides/app-stores.md
+++ b/versions/unversioned/guides/app-stores.md
@@ -47,7 +47,7 @@ Try your app on tablets in addition to handsets. Even if you have `ios.supportsT
 
 ## System permissions dialogs on iOS
 
-If your app asks for [system permissions](../sdk/permissions.html) from the user, e.g. to use the device's camera, access photos, or send notifications, Apple requires an explanation for how your app makes use of that data. Expo will automatically provide a boilerplate reason for you, such as "Allow cool-app to access the camera." If you would like to provide more information, you can override these values using the [ios.infoPlist](./guides/configuration.html#infoplist) key in `app.json`, for example:
+If your app asks for [system permissions](../sdk/permissions.html) from the user, e.g. to use the device's camera, or access photos, Apple requires an explanation for how your app makes use of that data. Expo will automatically provide a boilerplate reason for you, such as "Allow cool-app to access the camera." If you would like to provide more information, you can override these values using the [ios.infoPlist](./guides/configuration.html#infoplist) key in `app.json`, for example:
 
 ```
 "infoPlist": {


### PR DESCRIPTION
I mentioned the wrong issue on the commit body.
The correct is this one: https://github.com/expo/expo/issues/1129

It seems that setting the 'infoPlist' for notification is not needed. (https://github.com/expo/expo/issues/1129)
This mention that I'm deleting seems to indicate that it is needed...
It took me a while to figure it out and it seems that mentioning this here will only create more confusion for others as it has created for me.

Thanks for your awesome work!!!