### PR TITLE
Update segment.md

### DIFF
--- a/versions/unversioned/sdk/segment.md
+++ b/versions/unversioned/sdk/segment.md
@@ -17,6 +17,8 @@ Accepts an object with the following keys:
 -   **androidWriteKey (_string_)** -- Write key for Android source.
 -   **iosWriteKey (_string_)** -- Write key for iOS source.
 
+**Note**: The parameters are case sensitive, so `iOSWriteKey` and the like will not work.  
+
 ### `Expo.Segment.identify(userId)`
 
 Associates the current user with a user ID. Call this after calling [`Expo.Segment.initialize()`](#exposegmentinitialize "Expo.Segment.initialize") but before other segment calls. See <https://segment.com/docs/spec/identify/>.


### PR DESCRIPTION
Writing `iOSWriteKey` instead instantly crashes the Expo client on iOS with no errors, see https://github.com/expo/expo/issues/1535

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
