### PR TITLE
url not found

### DIFF
--- a/versions/v25.0.0/introduction/installation.md
+++ b/versions/v25.0.0/introduction/installation.md
@@ -8,7 +8,7 @@ There are two tools that you need to develop apps with Expo - a desktop developm
 
 XDE stands for Expo Development Environment. It is a standalone desktop app that includes all dependencies you'll need to get started.
 
-Download the latest version of XDE for [macOS](https://xde-updates.exponentjs.com/download/mac), [Windows (64-bit)](https://xde-updates.exponentjs.com/download/win32), or [Linux](https://xde-updates.exponentjs.com/download/linux-x86_64).
+Download the latest version of XDE for [macOS](https://xde-updates.exponentjs.com/download/mac), [Windows (64-bit)](https://xde-updates.exponentjs.com/download/win64), or [Linux](https://xde-updates.exponentjs.com/download/linux-x86_64).
 
 On Linux, open with `chmod a+x xde*.AppImage` and `./xde*.AppImage`.
 


### PR DESCRIPTION
Window 64 hosted in url with path https://xde-updates.exponentjs.com/download/win64 not https://xde-updates.exponentjs.com/download/win32.
best regards

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
