### PR TITLE
fixes "why expo on ios" target

### DIFF
--- a/versions/unversioned/sdk/payments.md
+++ b/versions/unversioned/sdk/payments.md
@@ -12,7 +12,7 @@ If you haven't done payments with Stripe before, create an account with [Stripe]
 
 ## Adding the Payments Module on iOS
 
-The Payments module is currently only supported through ExpoKit on iOS (to understand why, refer to [Why ExpoKit on iOS?](#why-expokit-on-ios?)).
+The Payments module is currently only supported through ExpoKit on iOS (to understand why, refer to [Why ExpoKit on iOS?](#why-expokit-on-ios)).
 
 First, detach your Expo project using ExpoKit (refer to [Detach to ExpoKit]('../guides/detach.md') for more information). Then, navigate to and open `your-project-name/ios/Podfile`. Add "Payments" to your Podfile's subspecs. Example:
 

--- a/versions/v25.0.0/sdk/payments.md
+++ b/versions/v25.0.0/sdk/payments.md
@@ -12,7 +12,7 @@ If you haven't done payments with Stripe before, create an account with [Stripe]
 
 ## Adding the Payments Module on iOS
 
-The Payments module is currently only supported through ExpoKit on iOS (to understand why, refer to [Why ExpoKit on iOS?](#why-expokit-on-ios?)).
+The Payments module is currently only supported through ExpoKit on iOS (to understand why, refer to [Why ExpoKit on iOS?](#why-expokit-on-ios)).
 
 First, detach your Expo project using ExpoKit (refer to [Detach to ExpoKit](../guides/detach.md) for more information). Then, navigate to and open `your-project-name/ios/Podfile`. Add "Payments" to your Podfile's subspecs. Example:
 


### PR DESCRIPTION
<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
