### PR TITLE
replace call registerForPushNotificationsAsync

### DIFF
--- a/versions/v25.0.0/guides/push-notifications.md
+++ b/versions/v25.0.0/guides/push-notifications.md
@@ -90,7 +90,7 @@ import {
   View,
 } from 'react-native';
 
-import registerForPushNotificationsAsync from 'registerForPushNotificationsAsync';
+import registerForPushNotificationsAsync from '../api/registerForPushNotificationsAsync';
 
 export default class AppContainer extends React.Component {
   state = {


### PR DESCRIPTION
#216 a user was open a new issue because are thinking that `registerForPushNotificationsAsync ` that is a module 