### PR TITLE
Add list of Android camera permissions

### DIFF
--- a/versions/v25.0.0/sdk/camera.md
+++ b/versions/v25.0.0/sdk/camera.md
@@ -6,7 +6,7 @@ A React component that renders a preview for the device's either front or back c
 
 > **Note**: Only one Camera preview is supported by Expo right now. When using navigation, the best practice is to unmount previously rendered `Camera` component so next screens can use camera without issues.
 
-Requires `Permissions.CAMERA`. Video recording requires `Permissions.AUDIO_RECORDING`.
+Requires `Permissions.CAMERA`. Video recording requires `Permissions.AUDIO_RECORDING`. On Android, you may also require `Permissions.READ_INTERNAL_STORAGE`, `Permissions.READ_EXTERNAL_STORAGE`, & `Permissions.WRITE_EXTERNAL_STORAGE`.
 
 ### Basic Example
 


### PR DESCRIPTION
Camera on Android broke for me in the latest release due to missing permissions

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
