### PR TITLE
Fix face detector function name

### DIFF
--- a/versions/unversioned/sdk/facedetector.md
+++ b/versions/unversioned/sdk/facedetector.md
@@ -29,7 +29,7 @@ detectFaces = async (imageUri) => {
 // ...
 ```
 
-### `detectFaces`
+### `detectFacesAsync`
 
 Detect faces on a picture.
 

--- a/versions/unversioned/sdk/facedetector.md
+++ b/versions/unversioned/sdk/facedetector.md
@@ -24,7 +24,7 @@ import { FaceDetector } from 'expo';
 // ...
 detectFaces = async (imageUri) => {
   const options = { mode: FaceDetector.Constants.Mode.fast };
-  return await FaceDetector.detectFaces(imageUri, options);
+  return await FaceDetector.detectFacesAsync(imageUri, options);
 };
 // ...
 ```


### PR DESCRIPTION
Found a small miss match in function names. The sdk uses detectFacesAsync to detect faces on a picture and is named as detectFaces in the docs
