### PR TITLE
Fix preloading assets link in Icon docs

### DIFF
--- a/versions/unversioned/guides/icons.md
+++ b/versions/unversioned/guides/icons.md
@@ -25,7 +25,7 @@ This component loads the Ionicons font if it hasn't been loaded already, and ren
 
 `import { Ionicons } from '@expo/vector-icons';` instead of.. `import Ionicons from 'react-native-vector-icons/Ionicons';`.
 
-> **Note:** As with [any custom font](using-custom-fonts.html#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](assets.html#all-about-assets).
+> **Note:** As with [any custom font](using-custom-fonts.html#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](https://docs.expo.io/versions/latest/guides/preloading-and-caching-assets).
 
 ## Custom Icon Fonts
 

--- a/versions/v26.0.0/guides/icons.md
+++ b/versions/v26.0.0/guides/icons.md
@@ -25,7 +25,7 @@ This component loads the Ionicons font if it hasn't been loaded already, and ren
 
 `import { Ionicons } from '@expo/vector-icons';` instead of.. `import Ionicons from 'react-native-vector-icons/Ionicons';`.
 
-> **Note:** As with [any custom font](using-custom-fonts.html#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](assets.html#all-about-assets).
+> **Note:** As with [any custom font](using-custom-fonts.html#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](https://docs.expo.io/versions/latest/guides/preloading-and-caching-assets).
 
 ## Custom Icon Fonts
 


### PR DESCRIPTION
This previously linked to the assets page instead of the preloading and caching assets guide, and there's no link from the former to the latter so it was a little confusing!
