### PR TITLE
Missing Required for Android in createCalendarAsync

### DIFF
--- a/versions/v27.0.0/sdk/calendar.md
+++ b/versions/v27.0.0/sdk/calendar.md
@@ -48,7 +48,7 @@ Creates a new calendar on the device, allowing events to be added later and disp
     -   **allowedAttendeeTypes (_array_)** -- (Android only)
     -   **isVisible (_boolean_)** -- (Android only)
     -   **isSynced (_boolean_)** -- (Android only)
-    -   **accessLevel (_string_)** -- (Android only)
+    -   **accessLevel (_string_)** -- Required (Android only)
 
 #### Returns
 


### PR DESCRIPTION
accessLevel parameter is required when creating a new calendar in Android, as you can see in this file : 
https://github.com/expo/expo/blob/master/android/expoview/src/main/java/abi27_0_0/host/exp/exponent/modules/api/CalendarModule.java (line 535)
