### PR TITLE
Add Hashnode's Expo community link

### DIFF
--- a/versions/v27.0.0/introduction/community.md
+++ b/versions/v27.0.0/introduction/community.md
@@ -8,4 +8,4 @@ Want to chat about Expo? The best way to get in touch with our team and other pe
 - [Request an invitation](https://slack.expo.io/) to our [Slack](https://expo-developers.slack.com/).
 - [Follow us on Twitter @expo_io](https://twitter.com/expo_io)
 - [Become a contributor on Github](https://github.com/expo)
-- [Ask a question on Hashnode](https://hashnode.com/n/expo)
+- [Expo Developers Community on Hashnode](https://hashnode.com/n/expo)

--- a/versions/v27.0.0/introduction/community.md
+++ b/versions/v27.0.0/introduction/community.md
@@ -8,3 +8,4 @@ Want to chat about Expo? The best way to get in touch with our team and other pe
 - [Request an invitation](https://slack.expo.io/) to our [Slack](https://expo-developers.slack.com/).
 - [Follow us on Twitter @expo_io](https://twitter.com/expo_io)
 - [Become a contributor on Github](https://github.com/expo)
+- [Ask a question on Hashnode](https://hashnode.com/n/expo)

--- a/versions/v27.0.0/introduction/community.md
+++ b/versions/v27.0.0/introduction/community.md
@@ -8,4 +8,4 @@ Want to chat about Expo? The best way to get in touch with our team and other pe
 - [Request an invitation](https://slack.expo.io/) to our [Slack](https://expo-developers.slack.com/).
 - [Follow us on Twitter @expo_io](https://twitter.com/expo_io)
 - [Become a contributor on Github](https://github.com/expo)
-- [Expo Developers Community on Hashnode](https://hashnode.com/n/expo)
+- [Follow Expo Community on Hashnode](https://hashnode.com/n/expo)


### PR DESCRIPTION
Expo community on Hashnode has started growing in size recently. It would be great if this community is linked from the official docs.

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
