### PR TITLE
Dev server won't run without babel-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Then `cd` into the downloaded directory and install dependencies with:
 yarn
 ```
 
-Then you can run the app with:
+Then you need to install babel-cli
+
+```sh
+yarn global add babel-cli
+```
+
+Then you can run the app with (make sure you have no server running on port 3000):
 
 ```sh
 yarn run dev


### PR DESCRIPTION
add instruction to install babel-cli otherwise yarn run dev fails.