### PR TITLE
Fix wrong destructuring property in Expo.Audio.Sound.create example

### DIFF
--- a/versions/unversioned/sdk/audio.md
+++ b/versions/unversioned/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v19.0.0/sdk/audio.md
+++ b/versions/v19.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v20.0.0/sdk/audio.md
+++ b/versions/v20.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v21.0.0/sdk/audio.md
+++ b/versions/v21.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v22.0.0/sdk/audio.md
+++ b/versions/v22.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v23.0.0/sdk/audio.md
+++ b/versions/v23.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v24.0.0/sdk/audio.md
+++ b/versions/v24.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v25.0.0/sdk/audio.md
+++ b/versions/v25.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v26.0.0/sdk/audio.md
+++ b/versions/v26.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v27.0.0/sdk/audio.md
+++ b/versions/v27.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );

--- a/versions/v28.0.0/sdk/audio.md
+++ b/versions/v28.0.0/sdk/audio.md
@@ -117,7 +117,7 @@ A static convenience method to construct and load a sound is also provided:
 
     ```javascript
     try {
-      const { soundObject, status } = await Expo.Audio.Sound.create(
+      const { sound: soundObject, status } = await Expo.Audio.Sound.create(
         require('./assets/sounds/hello.mp3'),
         { shouldPlay: true }
       );


### PR DESCRIPTION
`Expo.Audio.Sound.create` returns a [`Promise` that resolves to an object with `sound` as a property](https://docs.expo.io/versions/v28.0.0/sdk/audio#sound--the-newly-created-and-loaded), but the example tries to destructure with the key `soundObject` which will always be `undefined`.

Fix: use `sound` for the destructuring assignment and rename it to `soundObject` so that it's consistent with the other examples.