### PR TITLE
Fix typo in sdk/fonts.md

### DIFF
--- a/versions/unversioned/sdk/font.md
+++ b/versions/unversioned/sdk/font.md
@@ -19,7 +19,7 @@ Convenience form of [`Expo.Font.loadAsync()`](#expofontloadasync "Expo.Font.load
 ```javascript
 Expo.Font.loadAsync({
   Montserrat: require('./assets/fonts/Montserrat.ttf'),
-  'Montserrat-SemiBold': require('./assets/fontsMontserrat-SemiBold.ttf'),
+  'Montserrat-SemiBold': require('./assets/fonts/Montserrat-SemiBold.ttf'),
 });
 ```
 

--- a/versions/v20.0.0/sdk/font.md
+++ b/versions/v20.0.0/sdk/font.md
@@ -39,7 +39,7 @@ Convenience form of [`Expo.Font.loadAsync()`](#expofontloadasync "Expo.Font.load
 ```javascript
 Expo.Font.loadAsync({
   Montserrat: require('./assets/fonts/Montserrat.ttf'),
-  'Montserrat-SemiBold': require('./assets/fontsMontserrat-SemiBold.ttf'),
+  'Montserrat-SemiBold': require('./assets/fonts/Montserrat-SemiBold.ttf'),
 });
 ```
 


### PR DESCRIPTION
<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->

This simply updates a typo in the on the `sdk/fonts.md` page. It is included on both the current version and the `unversioned` files.