### PR TITLE
Enhance description of the expected slug value in the configuration docs

### DIFF
--- a/versions/unversioned/workflow/configuration.md
+++ b/versions/unversioned/workflow/configuration.md
@@ -31,7 +31,7 @@ A short description of what your app is and why it is great.
 
 ## "slug"
 
-**Required**. The friendly url name for publishing. eg: `expo.io/@your-username/slug`.
+**Required**. The friendly url name for publishing. eg: `my-app-name` will refer to the `expo.io/@your-username/my-app-name` project.
 
 ## "privacy"
 


### PR DESCRIPTION
This PR addresses the confusion reported here: https://forums.expo.io/t/solved-slug-does-not-match-pattern-a-za-z0-9/425