### PR TITLE
fix usesIcloudStorage typo

### DIFF
--- a/versions/unversioned/workflow/configuration.md
+++ b/versions/unversioned/workflow/configuration.md
@@ -337,7 +337,7 @@ Configuration for how and when the app should request OTA JavaScript updates
       A boolean indicating if the app uses iCloud Storage for DocumentPicker. 
       See DocumentPicker docs for details.
     */
-    "useIcloudStorage": BOOLEAN,
+    "usesIcloudStorage": BOOLEAN,
 
     "config": {
       /*

--- a/versions/v26.0.0/workflow/configuration.md
+++ b/versions/v26.0.0/workflow/configuration.md
@@ -337,7 +337,7 @@ Configuration for how and when the app should request OTA JavaScript updates
       A boolean indicating if the app uses iCloud Storage for DocumentPicker. 
       See DocumentPicker docs for details.
     */
-    "useIcloudStorage": BOOLEAN,
+    "usesIcloudStorage": BOOLEAN,
 
     "config": {
       /*

--- a/versions/v27.0.0/workflow/configuration.md
+++ b/versions/v27.0.0/workflow/configuration.md
@@ -337,7 +337,7 @@ Configuration for how and when the app should request OTA JavaScript updates
       A boolean indicating if the app uses iCloud Storage for DocumentPicker. 
       See DocumentPicker docs for details.
     */
-    "useIcloudStorage": BOOLEAN,
+    "usesIcloudStorage": BOOLEAN,
 
     "config": {
       /*

--- a/versions/v28.0.0/workflow/configuration.md
+++ b/versions/v28.0.0/workflow/configuration.md
@@ -337,7 +337,7 @@ Configuration for how and when the app should request OTA JavaScript updates
       A boolean indicating if the app uses iCloud Storage for DocumentPicker. 
       See DocumentPicker docs for details.
     */
-    "useIcloudStorage": BOOLEAN,
+    "usesIcloudStorage": BOOLEAN,
 
     "config": {
       /*


### PR DESCRIPTION
`useIcloudStorage` -> `usesIcloudStorage` (missing 's')