### PR TITLE
Notifications fcm token

### DIFF
--- a/versions/unversioned/sdk/notifications.md
+++ b/versions/unversioned/sdk/notifications.md
@@ -167,7 +167,7 @@ Sets the number displayed in the app icon's badge to the given number. Setting t
 
 Note: Most people do not need to use this. It is easier to use `getExpoPushTokenAsync` unless you have a specific reason to need the actual device tokens. We also don't guarantee that the iOS and Android clients will continue expecting the same push notification payload format.
 
-Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](https://docs.expo.io/versions/latest/guides/using-fcm), it will return an FCM token, otherwise it will return a GCM token.
+Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](https://docs.expo.io/versions/latest/guides/using-fcm)), it will return an FCM token, otherwise it will return a GCM token.
 
 #### Arguments
 

--- a/versions/unversioned/sdk/notifications.md
+++ b/versions/unversioned/sdk/notifications.md
@@ -167,7 +167,7 @@ Sets the number displayed in the app icon's badge to the given number. Setting t
 
 Note: Most people do not need to use this. It is easier to use `getExpoPushTokenAsync` unless you have a specific reason to need the actual device tokens. We also don't guarantee that the iOS and Android clients will continue expecting the same push notification payload format.
 
-Returns a native APNS or GCM token that can be used with another push notification service.
+Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](https://docs.expo.io/versions/latest/guides/using-fcm), it will return an FCM token, otherwise it will return a GCM token.
 
 #### Arguments
 
@@ -177,5 +177,5 @@ Returns a native APNS or GCM token that can be used with another push notificati
 #### Returns
 
 A Promise that resolves to an object with the following fields:
--   **type (_string_)** -- Either "apns" or "gcm".
+-   **type (_string_)** -- Either "apns", "fcm", or "gcm".
 -   **data (_string_)** -- The push token as a string.

--- a/versions/v29.0.0/sdk/notifications.md
+++ b/versions/v29.0.0/sdk/notifications.md
@@ -167,7 +167,7 @@ Sets the number displayed in the app icon's badge to the given number. Setting t
 
 Note: Most people do not need to use this. It is easier to use `getExpoPushTokenAsync` unless you have a specific reason to need the actual device tokens. We also don't guarantee that the iOS and Android clients will continue expecting the same push notification payload format.
 
-Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](https://docs.expo.io/versions/latest/guides/using-fcm), it will return an FCM token, otherwise it will return a GCM token.
+Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](https://docs.expo.io/versions/latest/guides/using-fcm)), it will return an FCM token, otherwise it will return a GCM token.
 
 #### Arguments
 

--- a/versions/v29.0.0/sdk/notifications.md
+++ b/versions/v29.0.0/sdk/notifications.md
@@ -167,7 +167,7 @@ Sets the number displayed in the app icon's badge to the given number. Setting t
 
 Note: Most people do not need to use this. It is easier to use `getExpoPushTokenAsync` unless you have a specific reason to need the actual device tokens. We also don't guarantee that the iOS and Android clients will continue expecting the same push notification payload format.
 
-Returns a native APNS or GCM token that can be used with another push notification service.
+Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](https://docs.expo.io/versions/latest/guides/using-fcm), it will return an FCM token, otherwise it will return a GCM token.
 
 #### Arguments
 
@@ -177,5 +177,5 @@ Returns a native APNS or GCM token that can be used with another push notificati
 #### Returns
 
 A Promise that resolves to an object with the following fields:
--   **type (_string_)** -- Either "apns" or "gcm".
+-   **type (_string_)** -- Either "apns", "fcm", or "gcm".
 -   **data (_string_)** -- The push token as a string.


### PR DESCRIPTION
Just a clarification that if a user has followed the FCM guide here https://docs.expo.io/versions/latest/guides/using-fcm, they can get FCM tokens instead of GCM tokens from the `getDevicePushTokenAsync` function in the `Notifications` SDK

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
