### PR TITLE
Note regarding default Permissions

### DIFF
--- a/versions/unversioned/sdk/permissions.md
+++ b/versions/unversioned/sdk/permissions.md
@@ -154,7 +154,9 @@ On Android ask for this permission individually.
 
 ## Android: permissions equivalents inside `app.json`
 
-If you specified `android.permissions` inside your `app.json` ([read more about configuration](../workflow/configuration.html#android))  you have to use values corresponding to their `Expo.Permissions` equivalents. 
+If you specified `android.permissions` inside your `app.json` ([read more about configuration](../workflow/configuration.html#android))  you have to use values corresponding to their `Expo.Permissions` equivalents.
+
+> **Note:** If you haven't specified `android.permissions` inside your `app.json` your standalone Android app will require the permissions listed below by default.
 
 | Expo            | Android                                           |
 | --------------- | --------------------------------------------------|

--- a/versions/v30.0.0/sdk/permissions.md
+++ b/versions/v30.0.0/sdk/permissions.md
@@ -154,7 +154,9 @@ On Android ask for this permission individually.
 
 ## Android: permissions equivalents inside `app.json`
 
-If you specified `android.permissions` inside your `app.json` ([read more about configuration](../workflow/configuration.html#android))  you have to use values corresponding to their `Expo.Permissions` equivalents. 
+If you specified `android.permissions` inside your `app.json` ([read more about configuration](../workflow/configuration.html#android))  you have to use values corresponding to their `Expo.Permissions` equivalents.
+
+> **Note:** If you haven't specified `android.permissions` inside your `app.json` your standalone Android app will require the permissions listed below by default.
 
 | Expo            | Android                                           |
 | --------------- | --------------------------------------------------|


### PR DESCRIPTION
Note that the list of permissions listed at the end of document are default permissions which will end up in the standalone Android build if `android.permissions` is not set in `app.json`

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
