### PR TITLE
Procedure and shortcuts for opening developer menu 

### DIFF
--- a/versions/unversioned/workflow/development-mode.md
+++ b/versions/unversioned/workflow/development-mode.md
@@ -9,6 +9,7 @@ React Native includes some very useful tools for development: remote JavaScript 
 
 ![Screenshots of development mode in action](./development-mode.png)
 
+
 **This comes at a cost: your app runs slower in development mode.** You can toggle it on and off from Expo Dev Tools and Expo CLI. When you switch it, just close and re-open your app for the change to take effect. **Any time you are testing the performance of your app, be sure to disable development mode**.
 
 ## Toggling Development Mode in Expo Dev Tools
@@ -20,3 +21,6 @@ To enable development mode, make sure the "Production mode" switch is turned off
 ## Toggling Development Mode in Expo CLI
 
 In the terminal with your project running in Expo CLI, press `p` to toggle the production mode.
+
+## Showing the Developer Menu
+While you have the app open and development mode is enabled, shake your device to reveal the developer menu. If you are using an emulator, press ⌘+d for iOS or ctrl+m for Android.

--- a/versions/unversioned/workflow/development-mode.md
+++ b/versions/unversioned/workflow/development-mode.md
@@ -23,4 +23,4 @@ In the terminal with your project running in Expo CLI, press `p` to toggle the p
 
 ## Showing the Developer Menu
 
-While you have the app open and Development Mode is enabled, the developer menu is able to be shown. Depending on your settings of the Expo Client, you will either shake your device or use a two-finger force touch to reveal the Developer Menu. When using an emulator there are key commands to be used, press ⌘+D for iOS or Ctrl+M for Android.
+When in Development Mode, depending on your settings of the Expo Client, you will either shake your device or use a two-finger force touch to reveal the Developer Menu. When using an emulator, use the key command ⌘+D for iOS and Ctrl+M for Android.

--- a/versions/unversioned/workflow/development-mode.md
+++ b/versions/unversioned/workflow/development-mode.md
@@ -9,7 +9,6 @@ React Native includes some very useful tools for development: remote JavaScript 
 
 ![Screenshots of development mode in action](./development-mode.png)
 
-
 **This comes at a cost: your app runs slower in development mode.** You can toggle it on and off from Expo Dev Tools and Expo CLI. When you switch it, just close and re-open your app for the change to take effect. **Any time you are testing the performance of your app, be sure to disable development mode**.
 
 ## Toggling Development Mode in Expo Dev Tools

--- a/versions/unversioned/workflow/development-mode.md
+++ b/versions/unversioned/workflow/development-mode.md
@@ -22,4 +22,5 @@ To enable development mode, make sure the "Production mode" switch is turned off
 In the terminal with your project running in Expo CLI, press `p` to toggle the production mode.
 
 ## Showing the Developer Menu
-While you have the app open and development mode is enabled, shake your device to reveal the developer menu. If you are using an emulator, press ⌘+d for iOS or ctrl+m for Android.
+
+While you have the app open and Development Mode is enabled, the developer menu is able to be shown. Depending on your settings of the Expo Client, you will either shake your device or use a two-finger force touch to reveal the Developer Menu. When using an emulator there are key commands to be used, press ⌘+D for iOS or Ctrl+M for Android.

--- a/versions/v30.0.0/workflow/development-mode.md
+++ b/versions/v30.0.0/workflow/development-mode.md
@@ -20,3 +20,6 @@ To enable development mode, make sure the "Production mode" switch is turned off
 ## Toggling Development Mode in Expo CLI
 
 In the terminal with your project running in Expo CLI, press `p` to toggle the production mode.
+
+## Showing the Developer Menu
+While you have the app open and development mode is enabled, shake your device to reveal the developer menu. If you are using an emulator, press ⌘+d for iOS or ctrl+m for Android.

--- a/versions/v30.0.0/workflow/development-mode.md
+++ b/versions/v30.0.0/workflow/development-mode.md
@@ -23,4 +23,4 @@ In the terminal with your project running in Expo CLI, press `p` to toggle the p
 
 ## Showing the Developer Menu
 
-While you have the app open and Development Mode is enabled, the developer menu is able to be shown. Depending on your settings of the Expo Client, you will either shake your device or use a two-finger force touch to reveal the Developer Menu. When using an emulator there are key commands to be used, press ⌘+D for iOS or Ctrl+M for Android.
+When in Development Mode, depending on your settings of the Expo Client, you will either shake your device or use a two-finger force touch to reveal the Developer Menu. When using an emulator, use the key command ⌘+D for iOS and Ctrl+M for Android.

--- a/versions/v30.0.0/workflow/development-mode.md
+++ b/versions/v30.0.0/workflow/development-mode.md
@@ -22,4 +22,5 @@ To enable development mode, make sure the "Production mode" switch is turned off
 In the terminal with your project running in Expo CLI, press `p` to toggle the production mode.
 
 ## Showing the Developer Menu
-While you have the app open and development mode is enabled, shake your device to reveal the developer menu. If you are using an emulator, press ⌘+d for iOS or ctrl+m for Android.
+
+While you have the app open and Development Mode is enabled, the developer menu is able to be shown. Depending on your settings of the Expo Client, you will either shake your device or use a two-finger force touch to reveal the Developer Menu. When using an emulator there are key commands to be used, press ⌘+D for iOS or Ctrl+M for Android.


### PR DESCRIPTION
Adding Procedure and shortcuts because the image above on the page shows the developer menu but there is nothing on this page to assist with opening it.
