### PR TITLE
Add info about required Sentry scope.

### DIFF
--- a/versions/unversioned/guides/using-sentry.md
+++ b/versions/unversioned/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - Copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and selecting your project. Next go to the settings tab and copy the name of your project, we will need this. The "legacy name" will not work for our purposes.
 - Go to your organization settings by going to [sentry.io](https://sentry.io), press the button in the top left of your screen with the arrow beside it and select "organization settings". Copy the name of your organization. The "legacy name" will not work for our purposes.
 

--- a/versions/v23.0.0/guides/using-sentry.md
+++ b/versions/v23.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - You will now be prompted to configure your application, click the link "Get your DSN" and copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and clicking "Select a project" from the top of the screen, then choosing your project. This is where you will see exceptions reported later. For now, click "Project Settings" in the top right, and copy your project "Short name". Then click on the top left corner icon to expose the organizations in your account. Click on settings gear icon and copy the organization short name. You will need this info for your `app.json` settings.
 
 ### Install and configure Sentry

--- a/versions/v24.0.0/guides/using-sentry.md
+++ b/versions/v24.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - You will now be prompted to configure your application, click the link "Get your DSN" and copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and clicking "Select a project" from the top of the screen, then choosing your project. This is where you will see exceptions reported later. For now, click "Project Settings" in the top right, and copy your project "Short name". Then click on the top left corner icon to expose the organizations in your account. Click on settings gear icon and copy the organization short name. You will need this info for your `app.json` settings.
 
 ### Install and configure Sentry

--- a/versions/v25.0.0/guides/using-sentry.md
+++ b/versions/v25.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - You will now be prompted to configure your application, click the link "Get your DSN" and copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and clicking "Select a project" from the top of the screen, then choosing your project. This is where you will see exceptions reported later. For now, click "Project Settings" in the top right, and copy your project "Short name". Then click on the top left corner icon to expose the organizations in your account. Click on settings gear icon and copy the organization short name. You will need this info for your `app.json` settings.
 
 ### Install and configure Sentry

--- a/versions/v26.0.0/guides/using-sentry.md
+++ b/versions/v26.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - You will now be prompted to configure your application, click the link "Get your DSN" and copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and clicking "Select a project" from the top of the screen, then choosing your project. This is where you will see exceptions reported later. For now, click "Project Settings" in the top right, and copy your project "Short name". Then click on the top left corner icon to expose the organizations in your account. Click on settings gear icon and copy the organization short name. You will need this info for your `app.json` settings.
 
 ### Install and configure Sentry

--- a/versions/v27.0.0/guides/using-sentry.md
+++ b/versions/v27.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - You will now be prompted to configure your application, click the link "Get your DSN" and copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and clicking "Select a project" from the top of the screen, then choosing your project. This is where you will see exceptions reported later. For now, click "Project Settings" in the top right, and copy your project "Short name". Then click on the top left corner icon to expose the organizations in your account. Click on settings gear icon and copy the organization short name. You will need this info for your `app.json` settings.
 
 ### Install and configure Sentry

--- a/versions/v28.0.0/guides/using-sentry.md
+++ b/versions/v28.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - Copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and selecting your project. Next go to the settings tab and copy the name of your project, we will need this. The "legacy name" will not work for our purposes.
 - Go to your organization settings by going to [sentry.io](https://sentry.io), press the button in the top left of your screen with the arrow beside it and select "organization settings". Copy the name of your organization. The "legacy name" will not work for our purposes.
 

--- a/versions/v29.0.0/guides/using-sentry.md
+++ b/versions/v29.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - Copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and selecting your project. Next go to the settings tab and copy the name of your project, we will need this. The "legacy name" will not work for our purposes.
 - Go to your organization settings by going to [sentry.io](https://sentry.io), press the button in the top left of your screen with the arrow beside it and select "organization settings". Copy the name of your organization. The "legacy name" will not work for our purposes.
 

--- a/versions/v30.0.0/guides/using-sentry.md
+++ b/versions/v30.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - Copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and selecting your project. Next go to the settings tab and copy the name of your project, we will need this. The "legacy name" will not work for our purposes.
 - Go to your organization settings by going to [sentry.io](https://sentry.io), press the button in the top left of your screen with the arrow beside it and select "organization settings". Copy the name of your organization. The "legacy name" will not work for our purposes.
 

--- a/versions/v31.0.0/guides/using-sentry.md
+++ b/versions/v31.0.0/guides/using-sentry.md
@@ -22,7 +22,7 @@ It notifies you of exceptions that your users run into while using your app and 
 - [Sign up for a Sentry account](https://sentry.io/signup/)
 - Once you have signed up, you will be prompted to create a project. Enter the name of your project and continue.
 - Copy your "Public DSN", you will need it shortly.
-- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Copy your auth token and save it for later.
+- Go to the [Sentry API](https://sentry.io/api/) section and create an auth token. You can use the default configuration, this token will never be made available to users of your app. Ensure you have `project:write` selected under scopes. Copy your auth token and save it for later.
 - Go to your project dashboard by going to [sentry.io](https://sentry.io) and selecting your project. Next go to the settings tab and copy the name of your project, we will need this. The "legacy name" will not work for our purposes.
 - Go to your organization settings by going to [sentry.io](https://sentry.io), press the button in the top left of your screen with the arrow beside it and select "organization settings". Copy the name of your organization. The "legacy name" will not work for our purposes.
 


### PR DESCRIPTION
To save users time, add information which scope is needed
when generating Sentry's API token.

See: https://docs.sentry.io/clients/javascript/sourcemaps/#uploading-source-maps-to-sentry

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
