### PR TITLE
fix(facedetector): update constants in faceDetectorSettings example

### DIFF
--- a/versions/unversioned/sdk/facedetector.md
+++ b/versions/unversioned/sdk/facedetector.md
@@ -36,8 +36,8 @@ import { FaceDetector } from 'expo';
   onFacesDetected={this.handleFacesDetected}
   faceDetectorSettings={{
     mode: FaceDetector.Constants.Mode.fast,
-    detectLandmarks: FaceDetector.Constants.Mode.none,
-    runClassifications: FaceDetector.Constants.Mode.none,
+    detectLandmarks: FaceDetector.Constants.Landmarks.none,
+    runClassifications: FaceDetector.Constants.Classifications.none,
   }}
 />
 ```


### PR DESCRIPTION
<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
Update the FaceDetector documentation. The `faceDetectorSettings` example was using the wrong constants for landmarks and classifications.

I tried running the following command:
```sh
$ ./scripts/versionpatch.sh unversioned v31.0.0 v30.0.0 v29.0.0 v28.0.0 v27.0.0 v26.0.0 v25.0.0 v24.0.0 v23.0.0
```

but I was getting the error message: `can't find file to patch at input line 5`.