### PR TITLE
GoogleSignin for iOS in workflow/configuration is incorrect and throw…

### DIFF
--- a/versions/v31.0.0/workflow/configuration.md
+++ b/versions/v31.0.0/workflow/configuration.md
@@ -367,7 +367,11 @@ Configuration for how and when the app should request OTA JavaScript updates
 
         developers.google.com/identity/sign-in/ios/start-integrating
       */
-      "googleSignIn": STRING,
+      "googleSignIn": {
+        
+        "reservedClientId": STRING,
+
+      },
 
       /*
         The reserved client ID URL scheme. 


### PR DESCRIPTION
Following the instructions for setting up app.json - expo.ios.config.googleSignIn throws errors unless you turn it into an object and use reversedClientId  (which is not the clientId but instead reversedId). However it's weird that apiKey isn't a variable, as it is in android. 