### PR TITLE
Adding mandatory host header

### DIFF
--- a/versions/unversioned/guides/push-notifications.md
+++ b/versions/unversioned/guides/push-notifications.md
@@ -151,6 +151,7 @@ Although there are server-side SDKs in several languages to help you send push n
 Send a POST request to `https://exp.host/--/api/v2/push/send` with the following HTTP headers:
 
 ```
+host: exp.host
 accept: application/json
 accept-encoding: gzip, deflate
 content-type: application/json


### PR DESCRIPTION
Using a fairly low level HTTP API and the lack of a host header meant an annoying amount of time spent debugging the set-up. Without it you will see nginx 400 responses.